### PR TITLE
Hafaykon-Frontend-#31-Fix for beeing stuck when auth token expires

### DIFF
--- a/src/components/myExercises/index.jsx
+++ b/src/components/myExercises/index.jsx
@@ -10,22 +10,20 @@ const MyExercises = () => {
             <Card>
                 <h2 className="border-bottom">My Exercises</h2>
                 <br/>
-                <section class="stats">
-                <div className="row">
-                    <span>Modules:</span> 
-                    <span>2/7 completed</span>
-                </div>
-                <div className="row">
-                    <span>Units:</span> 
-                    <span>4/10 completed</span>
-                </div>
-                <div className="row">
-                    <span>Exercises:</span> 
-                    <span>34/58 completed</span>
-                </div>
-            </section>
-
-
+                <section className="stats">
+                    <div className="row">
+                        <span>Modules:</span> 
+                        <span>2/7 completed</span>
+                    </div>
+                    <div className="row">
+                        <span>Units:</span> 
+                        <span>4/10 completed</span>
+                    </div>
+                    <div className="row">
+                        <span>Exercises:</span> 
+                        <span>34/58 completed</span>
+                    </div>
+                </section>
                 <br/>
                 <section >
                     <Button

--- a/src/components/posts/index.jsx
+++ b/src/components/posts/index.jsx
@@ -1,13 +1,23 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import Post from '../post';
 import { getPosts } from '../../service/apiClient';
+import { AuthContext } from '../../context/auth';
 
 const Posts = () => {
   const [posts, setPosts] = useState([]);
 
+  const authContext = useContext(AuthContext);
+
   useEffect(() => {
-    getPosts().then(setPosts);
-  }, []);
+    getPosts()
+    .then(setPosts)
+    .catch((error) => {
+      console.error(error.message);
+      if (error.message === "Unauthorized (Likely expired token)") {
+        authContext.onLogout();
+      }
+    })}, []);
+
 
   return (
     <>

--- a/src/components/userListElement/index.jsx
+++ b/src/components/userListElement/index.jsx
@@ -27,7 +27,6 @@ const UserListElement = ({ user }) => {
     openModal();
   };
 
-  console.log(user);
   return (
     <div className="user-container">
       <article className="user">

--- a/src/service/apiClient.js
+++ b/src/service/apiClient.js
@@ -20,6 +20,17 @@ async function getPosts() {
 
 async function getUsers() {
   const res = await get('users');
+  if (res.status === 401) {
+    throw new Error('Unauthorized');
+  }
+  return res.data.users;
+}
+
+async function getUsersTest() {
+  const res = await fetch(API_URL + '/users');
+  if (res.status === 401) {
+    throw new Error('Unauthorized (Likely expired token)');
+  }
   return res.data.users;
 }
 
@@ -53,7 +64,16 @@ async function request(method, endpoint, data, auth = true) {
 
   const response = await fetch(`${API_URL}/${endpoint}`, opts);
 
+  // In the case of your auth token expiring, this error will be caught in posts and  trigger a LogOut.
+  // This works because refreshing the page will autmatically navigate to "/" where posts
+  // are fetched. (a little messy but it works (?))
+  // Without this, the user would be stuck in a loop of trying to fetch posts and getting a 401.
+  // without beeing able to navigate to Login to refresh their token.
+  if (response.status === 401) {
+    throw new Error('Unauthorized (Likely expired token)');
+  }
+
   return response.json();
 }
 
-export { login, getPosts, getUsers, register, createProfile };
+export { login, getPosts, getUsers, getUsersTest, register, createProfile };


### PR DESCRIPTION
In the case of your auth token expiring, an error in the request API will be caught in posts and  trigger a LogOut.
This works because refreshing the page will autmatically navigate to "/" where posts
are fetched. (a little messy but it works (?))
Without this, the user would be stuck in a loop of trying to fetch posts and getting a 401
without beeing able to navigate to Login to refresh their token.